### PR TITLE
Point to the correct repository and branch for deployments

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -9,7 +9,7 @@ end
 set :rails_env, fetch(:stage)
 set :rvm1_map_bins, -> { fetch(:rvm_map_bins).to_a.concat(%w[rake gem bundle ruby]).uniq }
 
-set :application, "consul"
+set :application, "participacyl"
 set :deploy_to, deploysecret(:deploy_to)
 set :ssh_options, port: deploysecret(:ssh_port)
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -13,7 +13,7 @@ set :application, "consul"
 set :deploy_to, deploysecret(:deploy_to)
 set :ssh_options, port: deploysecret(:ssh_port)
 
-set :repo_url, "https://github.com/consul/consul.git"
+set :repo_url, "https://github.com/rockandror/participacyl.git"
 
 set :revision, `git rev-parse --short #{fetch(:branch)}`.strip
 

--- a/config/deploy/preproduction.rb
+++ b/config/deploy/preproduction.rb
@@ -1,4 +1,4 @@
-set :branch, ENV["branch"] || :master
+set :branch, ENV["branch"] || :stable
 
 server deploysecret(:server1), user: deploysecret(:user), roles: %w[web app db importer cron background]
 server deploysecret(:server2), user: deploysecret(:user), roles: %w[web app db importer]

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,4 +1,4 @@
-set :branch, ENV["branch"] || :master
+set :branch, ENV["branch"] || :stable
 
 server deploysecret(:server1), user: deploysecret(:user), roles: %w[web app db importer cron background]
 #server deploysecret(:server2), user: deploysecret(:user), roles: %w(web app db importer cron background)

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,3 +1,3 @@
-set :branch, ENV["branch"] || :master
+set :branch, ENV["branch"] || :stable
 
 server deploysecret(:server), user: deploysecret(:user), roles: %w[web app db importer cron background]


### PR DESCRIPTION
## Objectives

Point to the correct repository for deployments.

Fetch the `stable` branch by default during deployments.

Update the application name in the configuration set-up file (`config/deploy.rb`) as we installed the application with the installer using the variable `app_name=participacyl`.  Some deployment tasks can fail without this change, like the whenever crontab update task.

# Crontab error
```
deploy@ubuntu:~$ crontab -l
# Begin Whenever generated tasks for: participacyl at: 2023-05-29 12:56:26 +0200
* * * * * /bin/bash -l -c 'date > ~/cron-test.txt'
0 5 * * * /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230529101753 && RAILS_ENV=production bundle exec rake -s sitemap:refresh --silent'
0 1 * * * /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230529101753 && RAILS_ENV=production bundle exec rake files:remove_old_cached_attachments --silent'
0 3 * * * /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230529101753 && RAILS_ENV=production bundle exec rake votes:reset_hot_score --silent'
0 0,2,4,6,8,10,12,14,16,18,20,22 * * * /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230529101753 && RAILS_ENV=production bundle exec rake -s stats:generate --silent'
@reboot /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230529101753 && bundle exec puma -C config/puma/production.rb'
@reboot /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230529101753 && RAILS_ENV=production bin/delayed_job -n 2 restart'
# End Whenever generated tasks for: participacyl at: 2023-05-29 12:56:26 +0200

# Begin Whenever generated tasks for: consul at: 2023-05-31 11:53:45 +0200
* * * * * /bin/bash -l -c 'date > ~/cron-test.txt'
0 5 * * * /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230530112702 && RAILS_ENV=production bundle exec rake -s sitemap:refresh --silent'
0 1 * * * /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230530112702 && RAILS_ENV=production bundle exec rake files:remove_old_cached_attachments --silent'
0 3 * * * /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230530112702 && RAILS_ENV=production bundle exec rake votes:reset_hot_score --silent'
0 0,2,4,6,8,10,12,14,16,18,20,22 * * * /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230530112702 && RAILS_ENV=production bundle exec rake -s stats:generate --silent'
@reboot /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230530112702 && bundle exec puma -C config/puma/production.rb'
# End Whenever generated tasks for: consul at: 2023-05-31 11:53:45 +0200
```

As you can see in the crontab definition above, there are two different entries generated by Whenever, one using the real application name used during the installation, `participacyl`, and the other one generated by Whenever accidentally during a deployment with the wrong application name.


After a new deployment with the correct application name the crontab was updated successfully:
```
# Begin Whenever generated tasks for: participacyl at: 2023-05-31 12:33:37 +0200
* * * * * /bin/bash -l -c 'date > ~/cron-test.txt'
0 5 * * * /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230531103209 && RAILS_ENV=production bundle exec rake -s sitemap:refresh --silent'
0 1 * * * /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230531103209 && RAILS_ENV=production bundle exec rake files:remove_old_cached_attachments --silent'
0 3 * * * /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230531103209 && RAILS_ENV=production bundle exec rake votes:reset_hot_score --silent'
0 0,2,4,6,8,10,12,14,16,18,20,22 * * * /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230531103209 && RAILS_ENV=production bundle exec rake -s stats:generate --silent'
@reboot /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230531103209 && bundle exec puma -C config/puma/production.rb'
# End Whenever generated tasks for: participacyl at: 2023-05-31 12:33:37 +0200
```