### PR TITLE
Restart the delayed_job process automatically when it crashes or stops

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -8,13 +8,15 @@ require "capistrano/bundler"
 require "capistrano/rails/assets"
 require "capistrano/rails/migrations"
 #require "capistrano/passenger"
-require "capistrano/delayed_job"
 require "whenever/capistrano"
 require "rvm1/capistrano3"
 
 require "capistrano/puma"
 install_plugin Capistrano::Puma, load_hooks: false
 install_plugin Capistrano::Puma::Daemon
+
+require "capistrano/systemd/multiservice"
+install_plugin Capistrano::Systemd::MultiService.new_service("delayed_job@", service_type: "user")
 
 #SCM: Git
 require "capistrano/scm/git"

--- a/Gemfile
+++ b/Gemfile
@@ -96,7 +96,7 @@ group :development do
   gem "capistrano", "~> 3.16.0", require: false
   gem "capistrano-bundler", "~> 2.0", require: false
   gem "capistrano-rails", "~> 1.6.1", require: false
-  gem "capistrano3-delayed-job", "~> 1.7.6"
+
   gem "capistrano3-puma", "~> 5.0.4"
   gem "erb_lint", "~> 0.0.37", require: false
   gem "github_changelog_generator", "~> 1.15.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/groovenauts/capistrano-systemd-multiservice.git
+  revision: 9ade1d3607f7d8a36fab30c5195137f7c219a1b6
+  branch: dependabot/bundler/capistrano-gte-3.7.0-and-lt-3.18.0
+  specs:
+    capistrano-systemd-multiservice (0.1.0.beta12)
+      capistrano (>= 3.7.0, < 3.18.0)
+
 GEM
   remote: https://rubygems.org/
   remote: https://rails-assets.org/
@@ -100,9 +108,6 @@ GEM
     capistrano-rails (1.6.1)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
-    capistrano3-delayed-job (1.7.6)
-      capistrano (~> 3.0, >= 3.0.0)
-      daemons (~> 1.3)
     capistrano3-puma (5.0.4)
       capistrano (~> 3.7)
       capistrano-bundler
@@ -698,7 +703,7 @@ DEPENDENCIES
   capistrano (~> 3.16.0)
   capistrano-bundler (~> 2.0)
   capistrano-rails (~> 1.6.1)
-  capistrano3-delayed-job (~> 1.7.6)
+  capistrano-systemd-multiservice!
   capistrano3-puma (~> 5.0.4)
   capybara (~> 3.35.3)
   capybara-webmock (~> 0.6.0)

--- a/Gemfile_custom
+++ b/Gemfile_custom
@@ -23,3 +23,8 @@
 ###### Other gems ######
 #
 # Add your custom gem dependencies here
+
+gem "capistrano-systemd-multiservice",
+  require: false,
+  git: "https://github.com/groovenauts/capistrano-systemd-multiservice.git",
+  branch: "dependabot/bundler/capistrano-gte-3.7.0-and-lt-3.18.0"

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -46,6 +46,4 @@ end
 
 every :reboot do
   command "cd #{@path} && bundle exec puma -C config/puma/#{@environment}.rb"
-  # Number of workers must be kept in sync with capistrano's delayed_job_workers
-  command "cd #{@path} && RAILS_ENV=#{@environment} bin/delayed_job -n 2 restart"
 end

--- a/config/systemd/delayed_job@.service.erb
+++ b/config/systemd/delayed_job@.service.erb
@@ -1,0 +1,24 @@
+# Keep delayed job workers running using systemd on ubuntu
+# Usage
+# Start "systemctl --user start delayed_job@{0..3}" to start 4 worker instances
+# Enable "systemctl --user enable delayed_job@{0..3}" to enable 4 worker instances
+# Restart "systemctl --user restart delayed_job@{0..3}" to restart 4 worker instances
+# Disable "systemctl --user disable delayed_job@{0..3}" to disable 4 worker instances
+# Stop "systemctl --user stop delayed_job@{0..3}" to stop 4 worker instances
+[Unit]
+Description = <%= fetch(:application) %> delayed_job (instance %i)
+AssertPathExists = <%= current_path %>
+
+[Service]
+Type = forking
+WorkingDirectory = <%= current_path %>
+ExecStart=/bin/bash -lc 'RAILS_ENV=<%= fetch(:rails_env) %> bin/delayed_job -i %i start'
+ExecStop=/bin/bash -lc 'RAILS_ENV=<%= fetch(:rails_env) %> bin/delayed_job -i %i stop'
+ExecReload = /bin/kill -HUP $MAINPID
+PIDFile = <%= shared_path %>/tmp/pids/delayed_job.%i.pid
+# Restart after 1 minute delay
+Restart=on-failure
+RestartSec=60
+
+[Install]
+WantedBy = default.target


### PR DESCRIPTION
# References
We found many times delayed_job process stopped. We do not know the reason but it periodically stops.

https://wiki.archlinux.org/title/systemd/User

> Basic setup

>All the user units will be placed in ~/.config/systemd/user/. If you want to start units on first login, execute systemctl --user enable unit for any unit you want to be autostarted.
Tip: If you want to enable a unit for all users rather than the user executing the systemctl command, run systemctl --global enable unit as root. Similarly for disable.

> Automatic start-up of systemd user instances

> The systemd user instance is started after the first login of a user and killed after the last session of the user is closed. Sometimes it may be useful to start it right after boot, and keep the systemd user instance running after the last session closes, for instance to have some user process running without any open session. Lingering is used to that effect. Use the following command to enable lingering for specific user:

> `loginctl enable-linger username`

# Objective
This PR provides a way so the OS can restart the process automatically on-failure.

We are using a systemd `--user` unit so the process owner (`deploy` by default) can restart it by itself without sudo privileges.
# How
1º Do not reboot delayed_job processes via whenever on system reboot, as we will do it through systemd
2º Uninstall `capistrano3-delayed_job` gem
3º Install `capistrano-systemd-multiservice` gem and add the systemd unit file to manage delayed_job processes.

# Preproduction manual testing
1º Connect to the preproduction server and verify the delayed_job process was stopped
2º Create the folders `~/.config/systemd/user`. The next step will fail otherwise.
3º Upload systemd unit file for delayed_jobs from this branch with: 
   `cap preproduction systemd:delayed_job@:setup`
4º Start delayed_job with systemd: 
   `cap preproduction systemd:delayed_job@:start`
5º Deploy this branch to the server so it bundles the project again and restarts the delayed_job processes through Capistrano by using the new systemd uploaded file.
6º Run `sudo loginctl enable-linger deploy` to enable lingering for the deploy user.
7º Reboot the system and check how the systemd processes are launch automatically after server reboot and not by the whenever task.

