### PR TITLE
Admin documents

### DIFF
--- a/app/controllers/custom/admin/site_customization/documents_controller.rb
+++ b/app/controllers/custom/admin/site_customization/documents_controller.rb
@@ -1,0 +1,14 @@
+require_dependency Rails.root.join("app", "controllers", "admin", "site_customization", "documents_controller").to_s
+
+class Admin::SiteCustomization::DocumentsController < Admin::SiteCustomization::BaseController
+  private
+
+    alias_method :consul_initialize_document, :initialize_document
+
+    def initialize_document
+      document = consul_initialize_document
+      document.documentable_id = params[:document][:documentable_id]
+      document.documentable_type = "Legislation::Proposal"
+      document
+    end
+end

--- a/app/views/custom/admin/site_customization/documents/index.html.erb
+++ b/app/views/custom/admin/site_customization/documents/index.html.erb
@@ -1,0 +1,46 @@
+<h2 class="inline-block"><%= t("admin.documents.index.title") %></h2>
+
+<%= link_to t("admin.documents.index.new_link"),
+            new_admin_site_customization_document_path,
+            class: "button float-right" %>
+
+<% if @documents.any? %>
+  <h3><%= page_entries_info @documents %></h3>
+
+  <table>
+    <thead>
+      <tr>
+        <th scope="col"><%= t("admin.shared.title") %></th>
+        <th scope="col"><%= t("admin.documents.index.format") %></th>
+        <th scope="col"><%= t("admin.documents.index.size") %></th>
+        <th scope="col"><%= t("admin.documents.index.url") %></th>
+        <th scope="col"><%= t("admin.shared.actions") %></th>
+      </tr>
+    </thead>
+    <tbody id="documents">
+      <% @documents.each do |document| %>
+        <tr id="<%= dom_id(document) %>" class="document">
+          <td><%= document.title %></td>
+          <td><%= document.attachment.content_type %></td>
+          <td><%= number_to_human_size(document.attachment.byte_size) %></td>
+          <td><%= link_to document.title, document.attachment, target: :blank %></td>
+          <td>
+            <div class="small-12 medium-6 column">
+              <%= render Admin::TableActionsComponent.new(
+                document,
+                actions: [:destroy],
+                destroy_path: admin_site_customization_document_path(document)
+              ) %>
+            </div>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  <table>
+<% else %>
+  <div class="callout primary">
+    <%= t("admin.documents.index.no_documents") %>
+  </div>
+<% end %>
+
+<%= paginate @documents %>

--- a/app/views/custom/admin/site_customization/documents/index.html.erb
+++ b/app/views/custom/admin/site_customization/documents/index.html.erb
@@ -11,6 +11,7 @@
     <thead>
       <tr>
         <th scope="col"><%= t("admin.shared.title") %></th>
+        <th scope="col"><%= t("admin.documents.index.legislation.proposal_id") %></th>
         <th scope="col"><%= t("admin.documents.index.format") %></th>
         <th scope="col"><%= t("admin.documents.index.size") %></th>
         <th scope="col"><%= t("admin.documents.index.url") %></th>
@@ -21,6 +22,7 @@
       <% @documents.each do |document| %>
         <tr id="<%= dom_id(document) %>" class="document">
           <td><%= document.title %></td>
+          <td class="text-center"><%= document.documentable_id %></td>
           <td><%= document.attachment.content_type %></td>
           <td><%= number_to_human_size(document.attachment.byte_size) %></td>
           <td><%= link_to document.title, document.attachment, target: :blank %></td>

--- a/app/views/custom/admin/site_customization/documents/new.html.erb
+++ b/app/views/custom/admin/site_customization/documents/new.html.erb
@@ -1,0 +1,10 @@
+<h2><%= t("admin.documents.new.title") %></h2>
+
+<%= form_for @document,
+             url: admin_site_customization_documents_path do |f| %>
+  <%= f.file_field :attachment %>
+
+  <div class="margin-top">
+    <%= f.submit t("admin.documents.new.submit_button"), class: "button success" %>
+  </div>
+<% end %>

--- a/app/views/custom/admin/site_customization/documents/new.html.erb
+++ b/app/views/custom/admin/site_customization/documents/new.html.erb
@@ -2,7 +2,11 @@
 
 <%= form_for @document,
              url: admin_site_customization_documents_path do |f| %>
-  <%= f.file_field :attachment %>
+
+ <div class="small-12 medium-6 large-4">
+    <%= f.file_field :attachment %>
+    <%= f.text_field :documentable_id %>
+  </div>
 
   <div class="margin-top">
     <%= f.submit t("admin.documents.new.submit_button"), class: "button success" %>

--- a/app/views/custom/documents/_document.html.erb
+++ b/app/views/custom/documents/_document.html.erb
@@ -1,0 +1,21 @@
+<li id="<%= dom_id(document) %>">
+  <%= link_to t("documents.buttons.download_document"),
+              document.attachment, target: "_blank",
+              rel: "nofollow", class: "button hollow medium float-right" %>
+
+  <strong><%= document.title %></strong>
+  <br>
+  <small>
+    <%= document.humanized_content_type %>&nbsp;|&nbsp;
+    <%= number_to_human_size(document.attachment_file_size, precision: 2) %>
+  </small>
+
+  <% if can?(:destroy, document) %>
+    <br>
+    <%= link_to t("documents.buttons.destroy_document"),
+                  document,
+                  method: :delete,
+                  data: { confirm: t("documents.actions.destroy.confirm") },
+                  class: "delete" %>
+  <% end %>
+</li>

--- a/app/views/custom/documents/_document.html.erb
+++ b/app/views/custom/documents/_document.html.erb
@@ -8,6 +8,10 @@
   <small>
     <%= document.humanized_content_type %>&nbsp;|&nbsp;
     <%= number_to_human_size(document.attachment_file_size, precision: 2) %>
+    <% if document.admin %>
+      &nbsp;|&nbsp;
+      <%= sanitize(t("documents.uploaded_by", username: t("comments.comment.admin"), id: document.user.id)) %>
+    <% end %>
   </small>
 
   <% if can?(:destroy, document) %>

--- a/config/locales/custom/en/activerecord.yml
+++ b/config/locales/custom/en/activerecord.yml
@@ -1,0 +1,5 @@
+en:
+  activerecord:
+    attributes:
+      document:
+        documentable_id: Proposal ID

--- a/config/locales/custom/en/admin.yml
+++ b/config/locales/custom/en/admin.yml
@@ -1,0 +1,6 @@
+en:
+  admin:
+    documents:
+      index:
+        legislation:
+          proposal_id: Proposal ID

--- a/config/locales/custom/en/documents.yml
+++ b/config/locales/custom/en/documents.yml
@@ -1,0 +1,3 @@
+en:
+  documents:
+    uploaded_by: "Reply from JCYL uploaded by the <strong>%{username} #%{id}</strong>"

--- a/config/locales/custom/es/activerecord.yml
+++ b/config/locales/custom/es/activerecord.yml
@@ -1,0 +1,5 @@
+es:
+  activerecord:
+    attributes:
+      document:
+        documentable_id: ID de la Propuesta

--- a/config/locales/custom/es/admin.yml
+++ b/config/locales/custom/es/admin.yml
@@ -1,0 +1,6 @@
+es:
+  admin:
+    documents:
+      index:
+        legislation:
+          proposal_id: ID Propuesta

--- a/config/locales/custom/es/documents.yml
+++ b/config/locales/custom/es/documents.yml
@@ -1,0 +1,3 @@
+es:
+  documents:
+    uploaded_by: "Respuesta de la JCYL subido por el <strong>%{username} #%{id}</strong>"

--- a/spec/system/admin/site_customization/documents_spec.rb
+++ b/spec/system/admin/site_customization/documents_spec.rb
@@ -13,7 +13,7 @@ describe "Documents", :admin do
                               href: new_admin_site_customization_document_path
   end
 
-  scenario "Index" do
+  scenario "Index", :consul do
     3.times { create(:document, :admin) }
     1.times { create(:document) }
 
@@ -51,7 +51,7 @@ describe "Documents", :admin do
     expect(page).to have_selector("#documents .document", count: 2)
   end
 
-  scenario "Create" do
+  scenario "Create", :consul do
     visit new_admin_site_customization_document_path
 
     attach_file("document_attachment", file_fixture("logo.pdf"))

--- a/spec/system/custom/admin/site_customization/documents_spec.rb
+++ b/spec/system/custom/admin/site_customization/documents_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+describe "Documents", :admin do
+  let(:legislation_proposal) { create(:legislation_proposal, id: "555") }
+
+  scenario "Index" do
+    3.times { create(:document, :admin, documentable: legislation_proposal) }
+    1.times { create(:document) }
+
+    document = Document.first
+    url = polymorphic_path(document.attachment)
+
+    visit admin_site_customization_documents_path(locale: :es)
+
+    expect(page).to have_content "Hay 3 documentos"
+    expect(page).to have_content "ID Propuesta"
+    within "#document_#{document.id}" do
+      expect(page).to have_link document.title, href: url
+      expect(page).to have_content "555"
+    end
+  end
+
+  scenario "Create" do
+    visit new_admin_site_customization_document_path(locale: :es)
+
+    attach_file("document_attachment", file_fixture("logo.pdf"))
+    fill_in "ID de la Propuesta", with: "555"
+    click_button "Subir documento"
+
+    expect(page).to have_content "Documento creado correctamente"
+    expect(page).to have_content "555"
+    expect(page).to have_link "logo.pdf"
+  end
+end

--- a/spec/system/custom/legislation/proposals_spec.rb
+++ b/spec/system/custom/legislation/proposals_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+require "sessions_helper"
+
+describe "Legislation Proposals" do
+  let(:proposal) { create(:legislation_proposal) }
+  let(:admin) { create(:administrator) }
+  let!(:admin_document) { create(:document, :admin, documentable: proposal, user: admin.user) }
+  let!(:document) { create(:document, documentable: proposal) }
+
+  describe "Show" do
+    scenario "Mark documents uploaded by administrators" do
+      visit legislation_process_proposal_path(proposal.process, proposal, locale: :es)
+
+      within "#document_#{admin_document.id}" do
+        expect(page).to have_content "Respuesta de la JCYL subido por el Administrador ##{admin_document.user.id}"
+      end
+      within "#document_#{document.id}" do
+        expect(page).not_to have_content "Respuesta de la JCYL subido por el Administrador ##{document.user.id}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## References
Related PR: #11 

## Objectives
Allow linking a Document with a Legislation::Proposal through Admin SiteCustomization Documents section.

## Visual Changes
![AdminDocuments](https://github.com/juntadecastillayleon/participacyl/assets/16189/01cd0d3b-8173-466a-96be-bac5022ed5e8)
