### PR TITLE
Add tags to legislation processes

### DIFF
--- a/app/assets/stylesheets/custom/widgets/feeds/process.scss
+++ b/app/assets/stylesheets/custom/widgets/feeds/process.scss
@@ -1,0 +1,40 @@
+.feeds-processes {
+  @include flex-with-gap;
+  flex-wrap: wrap;
+
+  > * {
+    display: flex;
+    flex-basis: calc((#{rem-calc(720)} - 100%) * 999);
+    flex-direction: column;
+    flex-grow: 1;
+
+    > :nth-last-child(2) {
+      margin-bottom: auto;
+    }
+  }
+
+  .feed-item {
+    margin-top: $line-height;
+
+    &.open {
+      @include has-fa-icon(unlock-alt, solid);
+
+      &::before {
+        color: $color-success;
+      }
+    }
+
+    &.closed {
+      @include has-fa-icon(lock, solid);
+
+      &::before {
+        color: darken($alert-color, 5%);
+      }
+    }
+
+    span {
+      display: block;
+      font-size: $small-font-size;
+    }
+  }
+}

--- a/app/controllers/custom/legislation/processes_controller.rb
+++ b/app/controllers/custom/legislation/processes_controller.rb
@@ -1,0 +1,13 @@
+require_dependency Rails.root.join("app", "controllers", "legislation", "processes_controller").to_s
+
+class Legislation::ProcessesController
+  include Search
+
+  alias_method :consul_index, :index
+
+  def index
+    consul_index
+    @processes = @processes.search(@search_terms) if @search_terms.present?
+    @processes = @processes.filter_by(@advanced_search_terms)
+  end
+end

--- a/app/controllers/custom/legislation/processes_controller.rb
+++ b/app/controllers/custom/legislation/processes_controller.rb
@@ -9,5 +9,6 @@ class Legislation::ProcessesController
     consul_index
     @processes = @processes.search(@search_terms) if @search_terms.present?
     @processes = @processes.filter_by(@advanced_search_terms)
+    @tags = Tag.where(name: Legislation::Process::CATEGORIES)
   end
 end

--- a/app/models/custom/legislation/process.rb
+++ b/app/models/custom/legislation/process.rb
@@ -1,0 +1,6 @@
+require_dependency Rails.root.join("app", "models", "legislation", "process").to_s
+
+class Legislation::Process
+  include Filterable
+  scope :by_date_range, ->(date_range) { where(start_date: date_range).or(where(end_date: date_range)) }
+end

--- a/app/models/custom/legislation/process.rb
+++ b/app/models/custom/legislation/process.rb
@@ -3,4 +3,14 @@ require_dependency Rails.root.join("app", "models", "legislation", "process").to
 class Legislation::Process
   include Filterable
   scope :by_date_range, ->(date_range) { where(start_date: date_range).or(where(end_date: date_range)) }
+
+  CATEGORIES = ["ConsultaPrevia", "ParticipaciónCiudadana"].freeze
+
+  alias_method :consul_searchable_values, :searchable_values
+
+  def searchable_values
+    {
+      tag_list.join(" ") => "B"
+    }.merge(consul_searchable_values)
+  end
 end

--- a/app/models/custom/widget/feed.rb
+++ b/app/models/custom/widget/feed.rb
@@ -1,0 +1,7 @@
+require_dependency Rails.root.join("app", "models", "widget", "feed").to_s
+
+class Widget::Feed
+  def processes
+    Legislation::Process.published.order("created_at DESC").limit(limit)
+  end
+end

--- a/app/views/custom/admin/legislation/processes/_form.html.erb
+++ b/app/views/custom/admin/legislation/processes/_form.html.erb
@@ -192,6 +192,17 @@
 
   <div class="row">
     <div class="small-12 column">
+      <div id="category_tags" class="tags">
+        <%= f.label :category_tag_list, t("budgets.investments.form.tag_category_label") %>
+        <% Legislation::Process::CATEGORIES.each do |category| %>
+          <a class="js-add-tag-link"><%= category %></a>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="small-12 column">
       <%= render SDG::RelatedListSelectorComponent.new(f) %>
     </div>
   </div>

--- a/app/views/custom/legislation/processes/_process.html.erb
+++ b/app/views/custom/legislation/processes/_process.html.erb
@@ -20,6 +20,7 @@
 
     <div class="small-12 medium-11 column end">
       <%= render SDG::TagListComponent.new(process, limit: 5, linkable: false) %>
+      <%= render Shared::TagListComponent.new(process, limit: 5) %>
     </div>
   </div>
 

--- a/app/views/custom/legislation/processes/index.html.erb
+++ b/app/views/custom/legislation/processes/index.html.erb
@@ -1,0 +1,30 @@
+<% provide :title do %>
+  <%= t("layouts.header.collaborative_legislation") %> - <%= t("legislation.processes.index.filters.#{@current_filter}") %>
+<% end %>
+
+<%= render "shared/section_header", i18n_namespace: "legislation.processes.index.section_header", image: "legislation_processes" %>
+
+<div class="row">
+  <div id="legislation" class="legislation-list small-12 medium-9 column">
+
+    <%= render "shared/filter_subnav", i18n_namespace: "legislation.processes.index" %>
+
+    <div id="legislation-list">
+      <% if @processes.any? %>
+        <%= render @processes %>
+        <%= paginate @processes %>
+      <% else %>
+        <div class="callout primary margin-top">
+          <%= t("legislation.processes.index.no_#{@current_filter}_processes") %>
+        </div>
+      <% end %>
+
+      <div id="section_help" class="margin" data-magellan-target="section_help">
+        <p class="lead">
+          <strong><%= t("legislation.processes.index.section_footer.title") %></strong>
+        </p>
+        <p><%= t("legislation.processes.index.section_footer.description") %></p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/custom/legislation/processes/index.html.erb
+++ b/app/views/custom/legislation/processes/index.html.erb
@@ -42,4 +42,24 @@
       </div>
     </div>
   </div>
+
+  <div class="small-12 medium-3 column">
+    <aside class="margin-bottom">
+      <div id="tag-cloud">
+      <h2 class="sidebar-title"><%= t("legislation.processes.index.tags_cloud.tags") %></h2>
+      <br>
+      <ul class="no-bullet tag-cloud">
+        <% @tags.each do |tag| %>
+          <li class="inline-block">
+            <%= link_to legislation_processes_path(search: tag.name) do %>
+              <span class="tag"><%= tag.name %></span>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+
+      <%= render SDG::Goals::TagCloudComponent.new("Legislation::Process") %>
+    </aside>
+  </div>
 </div>

--- a/app/views/custom/legislation/processes/index.html.erb
+++ b/app/views/custom/legislation/processes/index.html.erb
@@ -2,10 +2,25 @@
   <%= t("layouts.header.collaborative_legislation") %> - <%= t("legislation.processes.index.filters.#{@current_filter}") %>
 <% end %>
 
-<%= render "shared/section_header", i18n_namespace: "legislation.processes.index.section_header", image: "legislation_processes" %>
+<% content_for :header_addon do %>
+  <%= render "shared/search_form",
+             search_path: legislation_processes_path(page: 1),
+             i18n_namespace: "legislation.processes.index.search_form" %>
+<% end %>
+
+<% if @search_terms || @advanced_search_terms %>
+  <%= render Shared::SearchResultsSummaryComponent.new(
+    results: @processes,
+    search_terms: @search_terms,
+    advanced_search_terms: @advanced_search_terms
+  ) %>
+<% else %>
+  <%= render "shared/section_header", i18n_namespace: "legislation.processes.index.section_header", image: "legislation_processes" %>
+<% end %>
 
 <div class="row">
   <div id="legislation" class="legislation-list small-12 medium-9 column">
+    <%= render Shared::AdvancedSearchComponent.new %>
 
     <%= render "shared/filter_subnav", i18n_namespace: "legislation.processes.index" %>
 

--- a/app/views/custom/welcome/_processes.html.erb
+++ b/app/views/custom/welcome/_processes.html.erb
@@ -1,0 +1,7 @@
+<div class="feeds-list">
+  <% @feeds.each do |feed| %>
+    <% if feed_processes?(feed) %>
+      <%= render Widget::Feeds::FeedComponent.new(feed) %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/custom/welcome/_processes.html.erb
+++ b/app/views/custom/welcome/_processes.html.erb
@@ -1,7 +1,32 @@
-<div class="feeds-list">
+<div class="feeds-list feeds-processes">
   <% @feeds.each do |feed| %>
     <% if feed_processes?(feed) %>
-      <%= render Widget::Feeds::FeedComponent.new(feed) %>
+      <% Legislation::Process::CATEGORIES.each do |category| %>
+        <% kind = feed.kind %>
+
+        <section id="feed_<%= kind %>" class="widget-feed feed-<%= kind %>">
+          <header>
+            <h2 class="title"><%= t("welcome.feed.most_active.#{category.underscore}") %></h2>
+          </header>
+
+          <% if feed.items.tagged_with(category).any? %>
+            <div class="feed-content">
+              <% feed.items.tagged_with(category).each do |item| %>
+                <div class="feed-item <%= item.status == :open ? "open" : "closed" %>">
+                  <%= link_to item.title, url_for(item) %>
+                  <span><%= t("welcome.feed.proposals", count: item.proposals.count) %></span>
+                </div>
+              <% end %>
+            </div>
+
+            <%= link_to t("welcome.feed.see_all.#{category.underscore}"),
+                        legislation_processes_path(search: category),
+                        class: "see-all" %>
+          <% else %>
+            <div class="no-items callout primary"><%= t("welcome.feed.no_items.#{kind}") %></div>
+          <% end %>
+        </section>
+      <% end %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/custom/welcome/index.html.erb
+++ b/app/views/custom/welcome/index.html.erb
@@ -1,0 +1,40 @@
+<% content_for :body_class, "home-page" %>
+
+<% content_for :canonical do %>
+  <%= render "shared/canonical", href: root_url %>
+<% end %>
+
+<%= render Shared::BannerComponent.new("homepage") %>
+
+<% provide :social_media_meta_tags do %>
+  <%= render "shared/social_media_meta_tags",
+              social_url: root_url %>
+<% end %>
+
+<%= render "shared/header", header: @header %>
+
+<main>
+  <%= render "feeds" %>
+
+  <div class="row">
+    <% if @cards.any? %>
+      <div class="small-12 column <%= "large-8" if feed_processes_enabled? %>">
+        <h2 class="title"><%= t("welcome.cards.title") %></h2>
+
+        <%= render "shared/cards", cards: @cards %>
+      </div>
+    <% end %>
+
+    <% if feed_processes_enabled? %>
+      <div class="small-12 large-4 column">
+        <%= render "processes" %>
+      </div>
+    <% end %>
+  </div>
+
+  <% if feature?("user.recommendations") && (@recommended_debates.present? || @recommended_proposals.present?) %>
+    <%= render "recommended",
+                recommended_debates: @recommended_debates,
+                recommended_proposals: @recommended_proposals %>
+  <% end %>
+</main>

--- a/app/views/custom/welcome/index.html.erb
+++ b/app/views/custom/welcome/index.html.erb
@@ -17,17 +17,17 @@
   <%= render "feeds" %>
 
   <div class="row">
-    <% if @cards.any? %>
-      <div class="small-12 column <%= "large-8" if feed_processes_enabled? %>">
-        <h2 class="title"><%= t("welcome.cards.title") %></h2>
-
-        <%= render "shared/cards", cards: @cards %>
+    <% if feed_processes_enabled? %>
+      <div class="small-12 column">
+        <%= render "processes" %>
       </div>
     <% end %>
 
-    <% if feed_processes_enabled? %>
-      <div class="small-12 large-4 column">
-        <%= render "processes" %>
+    <% if @cards.any? %>
+      <div class="small-12 column">
+        <h2 class="title"><%= t("welcome.cards.title") %></h2>
+
+        <%= render "shared/cards", cards: @cards %>
       </div>
     <% end %>
   </div>

--- a/config/locales/custom/es/general.yml
+++ b/config/locales/custom/es/general.yml
@@ -1,0 +1,12 @@
+es:
+  welcome:
+    feed:
+      most_active:
+        consulta_previa: Consultas previas
+        participación_ciudadana: Procesos de participación ciudadana
+      proposals:
+        one: 1 propuesta
+        other: "%{count} propuestas"
+      see_all:
+        consulta_previa: Ver todas las consultas previas
+        participación_ciudadana: Ver todos los procesos de participación ciudadana

--- a/config/locales/custom/es/legislation.yml
+++ b/config/locales/custom/es/legislation.yml
@@ -6,3 +6,5 @@ es:
           button: Buscar
           placeholder: Buscar procesos...
           title: Buscar
+        tags_cloud:
+          tags: Etiquetas

--- a/config/locales/custom/es/legislation.yml
+++ b/config/locales/custom/es/legislation.yml
@@ -1,0 +1,8 @@
+es:
+  legislation:
+    processes:
+      index:
+        search_form:
+          button: Buscar
+          placeholder: Buscar procesos...
+          title: Buscar

--- a/spec/models/custom/widget/feed_spec.rb
+++ b/spec/models/custom/widget/feed_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe Widget::Feed do
+  describe "#processes" do
+    let(:feed) { build(:widget_feed, kind: "processes", limit: 3) }
+
+    it "returns past processes" do
+      process = create(:legislation_process, :past)
+
+      expect(feed.processes).to eq [process]
+    end
+  end
+end

--- a/spec/models/widget/feed_spec.rb
+++ b/spec/models/widget/feed_spec.rb
@@ -67,7 +67,7 @@ describe Widget::Feed do
         expect(feed.processes.count).to be 3
       end
 
-      it "does not return past processes" do
+      it "does not return past processes", :consul do
         create(:legislation_process, :past)
 
         expect(feed.processes).to be_empty

--- a/spec/system/admin/homepage/homepage_spec.rb
+++ b/spec/system/admin/homepage/homepage_spec.rb
@@ -102,7 +102,7 @@ describe "Homepage", :admin do
       end
     end
 
-    scenario "Processes" do
+    scenario "Processes", :consul do
       5.times { create(:legislation_process) }
 
       visit admin_homepage_path

--- a/spec/system/custom/admin/homepage/homepage_spec.rb
+++ b/spec/system/custom/admin/homepage/homepage_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+describe "Homepage", :admin do
+  let!(:processes_feed) { create(:widget_feed, kind: "processes") }
+  before { Setting["homepage.widgets.feeds.processes"] = false }
+
+  scenario "Processes" do
+    5.times { create(:legislation_process, tag_list: ["ParticipaciónCiudadana"]) }
+    4.times { create(:legislation_process, tag_list: ["ConsultaPrevia"]) }
+
+    visit admin_homepage_path
+
+    within("#widget_feed_#{processes_feed.id}") do
+      select "3", from: "widget_feed_limit"
+      click_button "No"
+
+      expect(page).to have_button "Yes"
+    end
+
+    visit root_path
+
+    within ".feed-processes", text: "Consulta Previa" do
+      expect(page).to have_css(".feed-item", count: 3)
+    end
+
+    within ".feed-processes", text: "Participación Ciudadana" do
+      expect(page).to have_css(".feed-item", count: 3)
+    end
+  end
+end

--- a/spec/system/custom/advanced_search_spec.rb
+++ b/spec/system/custom/advanced_search_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+describe "Advanced search" do
+  scenario "Search legislation processes"do
+    create(:legislation_process, :open, title: "Open and interesting")
+    create(:legislation_process, :open, title: "Also open and also interesting")
+    create(:legislation_process, :open, title: "Open and ordinary")
+    create(:legislation_process, :past, title: "Past and interesting")
+    create(:legislation_process, :past, title: "Past and ordinary")
+
+    visit legislation_processes_path
+
+    expect(page).to have_content "Open and interesting"
+    expect(page).to have_content "Also open and also interesting"
+    expect(page).to have_content "Open and ordinary"
+    expect(page).not_to have_content "Past and interesting"
+    expect(page).not_to have_content "Past and ordinary"
+
+    click_button "Advanced search"
+    fill_in "With the text", with: "Interesting"
+    click_button "Filter"
+
+    expect(page).not_to have_content "Open and ordinary"
+    expect(page).not_to have_content "Past and interesting"
+    expect(page).not_to have_content "Past and ordinary"
+    expect(page).to have_content "Open and interesting"
+    expect(page).to have_content "Also open and also interesting"
+
+    click_link "Past"
+
+    expect(page).not_to have_content "Open and interesting"
+    expect(page).not_to have_content "Also open and also interesting"
+    expect(page).not_to have_content "Open and ordinary"
+    expect(page).not_to have_content "Past and ordinary"
+    expect(page).to have_content "Past and interesting"
+  end
+end

--- a/spec/system/custom/tags/legislation_processes_spec.rb
+++ b/spec/system/custom/tags/legislation_processes_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe "Tags" do
+  scenario "Filter from index" do
+    create(:legislation_process, tag_list: "ConsultaPrevia", title: "¿Qué opinas? ¡Participa ahora!")
+    create(:legislation_process, tag_list: "ParticipaciónCiudadana", title: "¡Tu voto cuenta!")
+
+    visit legislation_processes_path
+
+    within ".legislation", text: "¡Participa ahora!" do
+      expect(page).to have_content "ConsultaPrevia"
+      expect(page).not_to have_content "ParticipaciónCiudadana"
+    end
+
+    within ".legislation", text: "¡Tu voto cuenta!" do
+      expect(page).to have_content "ParticipaciónCiudadana"
+      expect(page).not_to have_content "ConsultaPrevia"
+    end
+
+    within("aside") { click_link "ParticipaciónCiudadana" }
+
+    expect(page).not_to have_content "¡Participa ahora!"
+    expect(page).to have_content "¡Tu voto cuenta!"
+  end
+end


### PR DESCRIPTION
## Objectives

* Make it possible to differentiate between "Consultas Previas" and "Procesos de Participación"
* Show closed processes in the homepage
* Add the option to search legislation processes by text, date or tag

## Visual Changes

![The homepage contains a list of processes for "Consulta Previa" and "Participa"](https://github.com/juntadecastillayleon/participacyl/assets/35156/0df43af8-318b-466d-8fb9-20a34b2655b4)

![The processes index contains filters to search by text, date or tag and lists the search results](https://github.com/juntadecastillayleon/participacyl/assets/35156/769bec37-625a-4642-a6e1-6e2b7d19f3ad)
