### PR TITLE
Change the default background color for processes

### DIFF
--- a/app/models/custom/legislation/process.rb
+++ b/app/models/custom/legislation/process.rb
@@ -3,6 +3,7 @@ require_dependency Rails.root.join("app", "models", "legislation", "process").to
 class Legislation::Process
   include Filterable
   scope :by_date_range, ->(date_range) { where(start_date: date_range).or(where(end_date: date_range)) }
+  attribute :background_color, default: "#f0f0f0"
 
   CATEGORIES = ["ConsultaPrevia", "ParticipaciónCiudadana"].freeze
 

--- a/app/views/custom/legislation/proposals/show.html.erb
+++ b/app/views/custom/legislation/proposals/show.html.erb
@@ -12,7 +12,7 @@
 
 <div class="row process-proposal">
   <div class="small-12 column">
-    <div class="header">
+    <div class="header" style="<%= css_for_process_header %>">
       <p class="process-title">
         <strong><%= t("legislation.proposals.process_title") %></strong>
       </p>

--- a/spec/models/custom/legislation/process_spec.rb
+++ b/spec/models/custom/legislation/process_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+describe Legislation::Process do
+  it "overwrites CONSUL's default background color" do
+    expect(build(:legislation_process).background_color).to eq "#f0f0f0"
+  end
+end

--- a/spec/system/admin/legislation/processes_spec.rb
+++ b/spec/system/admin/legislation/processes_spec.rb
@@ -189,7 +189,7 @@ describe "Admin collaborative legislation", :admin do
       expect(page).to have_css("img[alt='An example legislation process']")
     end
 
-    scenario "Default colors are present" do
+    scenario "Default colors are present", :consul do
       visit new_admin_legislation_process_path
 
       expect(find("#legislation_process_background_color").value).to eq "#e7f2fc"

--- a/spec/system/custom/admin/legislation/processes_spec.rb
+++ b/spec/system/custom/admin/legislation/processes_spec.rb
@@ -72,6 +72,13 @@ describe "Admin collaborative legislation", :admin do
       expect(page).to have_content "Summary of the process"
       expect(page).not_to have_content "Describing the process"
     end
+
+    scenario "Default colors are present" do
+      visit new_admin_legislation_process_path
+
+      expect(find("#legislation_process_background_color").value).to eq "#f0f0f0"
+      expect(find("#legislation_process_font_color").value).to eq "#222222"
+    end
   end
 
   context "Update" do


### PR DESCRIPTION
## Objectives

* Use the color asked by JCyL as a default background color for legislation processes