### PR TITLE
Fix tag assignment in processes administration

### DIFF
--- a/app/controllers/custom/admin/legislation/processes_controller.rb
+++ b/app/controllers/custom/admin/legislation/processes_controller.rb
@@ -1,0 +1,9 @@
+require_dependency Rails.root.join("app", "controllers", "admin", "legislation", "processes_controller").to_s
+
+class Admin::Legislation::ProcessesController
+  alias_method :consul_allowed_params, :allowed_params
+
+  def allowed_params
+    consul_allowed_params + [:tag_list]
+  end
+end

--- a/app/views/custom/admin/legislation/processes/_form.html.erb
+++ b/app/views/custom/admin/legislation/processes/_form.html.erb
@@ -193,11 +193,18 @@
   <div class="row">
     <div class="small-12 column">
       <div id="category_tags" class="tags">
-        <%= f.label :category_tag_list, t("budgets.investments.form.tag_category_label") %>
+        <%= f.label :tag_list, t("budgets.investments.form.tag_category_label") %>
+        <p class="help-text" id="tag-list-help-text"><%= t("legislation.processes.form.tags_instructions") %></p>
         <% Legislation::Process::CATEGORIES.each do |category| %>
-          <a class="js-add-tag-link"><%= category %></a>
+          <a href="#" class="js-add-tag-link"><%= category %></a>
         <% end %>
       </div>
+
+      <%= f.text_field :tag_list, value: @process.tag_list.to_s,
+                        label: false,
+                        class: "js-tag-list tag-autocomplete",
+                        aria: { describedby: "tag-list-help-text" },
+                        data: { js_url: suggest_tags_path } %>
     </div>
   </div>
 

--- a/config/locales/custom/es/legislation.yml
+++ b/config/locales/custom/es/legislation.yml
@@ -8,3 +8,5 @@ es:
           title: Buscar
         tags_cloud:
           tags: Etiquetas
+      form:
+        tags_instructions: Etiqueta este proceso. Puedes elegir entre las categorías propuestas o introducir las que desees

--- a/spec/system/admin/legislation/processes_spec.rb
+++ b/spec/system/admin/legislation/processes_spec.rb
@@ -311,6 +311,8 @@ describe "Admin collaborative legislation", :admin do
       visit edit_admin_legislation_process_path(process)
       within(".admin-content") { click_link "Proposals" }
 
+      expect(page).to have_content "Categories that users can select creating the proposal"
+
       fill_in "Categories", with: "recycling,bicycles,pollution"
       click_button "Save changes"
 

--- a/spec/system/custom/admin/legislation/processes_spec.rb
+++ b/spec/system/custom/admin/legislation/processes_spec.rb
@@ -113,5 +113,26 @@ describe "Admin collaborative legislation", :admin do
       expect(page).not_to have_content "Summarizing the process"
       expect(page).not_to have_content "Description of the process"
     end
+
+    scenario "Tag list" do
+      visit edit_admin_legislation_process_path(process)
+
+      expect(page).to have_field "Categories", with: ""
+
+      click_link "ConsultaPrevia"
+
+      expect(page).to have_field "Categories", with: '"ConsultaPrevia"'
+
+      click_button "Save changes"
+
+      expect(page).to have_content "Process updated successfully"
+
+      visit legislation_processes_path
+
+      within ".legislation" do
+        expect(page).to have_content "ConsultaPrevia"
+        expect(page).not_to have_content "ParticipaciónCiudadana"
+      end
+    end
   end
 end


### PR DESCRIPTION
## References

* We forgot to add these changes while working on pull request #18

## Objectives

* Allow assigning tags to new legislation processes in the admin section