### PR TITLE
Order legislation processes at the homepage as requested

### DIFF
--- a/app/models/custom/widget/feed.rb
+++ b/app/models/custom/widget/feed.rb
@@ -1,7 +1,33 @@
 require_dependency Rails.root.join("app", "models", "widget", "feed").to_s
 
 class Widget::Feed
-  def processes
-    Legislation::Process.published.order("created_at DESC").limit(limit)
+  def consultation_open_processes
+    Legislation::Process.open.published.tagged_with("ConsultaPrevia").
+                         order("end_date ASC").
+                         limit(limit)
+  end
+
+  def consultation_past_processes
+    open_count = consultation_open_processes.count
+    return Legislation::Process.none if open_count >= limit
+
+    Legislation::Process.past.published.tagged_with("ConsultaPrevia").
+                         order("end_date DESC").
+                         limit(limit - open_count)
+  end
+
+  def participation_open_processes
+    Legislation::Process.open.published.tagged_with("ParticipaciónCiudadana").
+                         order("end_date ASC").
+                         limit(limit)
+  end
+
+  def participation_past_processes
+    open_count = participation_open_processes.count
+    return Legislation::Process.none if open_count >= limit
+
+    Legislation::Process.past.published.tagged_with("ParticipaciónCiudadana").
+                         order("end_date DESC").
+                         limit(limit - open_count)
   end
 end

--- a/app/views/custom/welcome/_processes.html.erb
+++ b/app/views/custom/welcome/_processes.html.erb
@@ -9,13 +9,16 @@
             <h2 class="title"><%= t("welcome.feed.most_active.#{category.underscore}") %></h2>
           </header>
 
-          <% if feed.items.tagged_with(category).any? %>
+          <% collection = category == "ConsultaPrevia" ? "consultation" : "participation" %>
+          <% if feed.send("#{collection}_open_processes").any? || feed.send("#{collection}_past_processes").any? %>
             <div class="feed-content">
-              <% feed.items.tagged_with(category).each do |item| %>
-                <div class="feed-item <%= item.status == :open ? "open" : "closed" %>">
-                  <%= link_to item.title, url_for(item) %>
-                  <span><%= t("welcome.feed.proposals", count: item.proposals.count) %></span>
-                </div>
+              <% ["#{collection}_open_processes", "#{collection}_past_processes"].each do |method| %>
+                <% feed.send(method).each do |item| %>
+                  <div class="feed-item <%= method.include?("open") ? "open" : "closed" %>">
+                    <%= link_to item.title, url_for(item) %>
+                    <span><%= t("welcome.feed.proposals", count: item.proposals.count) %></span>
+                  </div>
+                <% end %>
               <% end %>
             </div>
 

--- a/spec/models/custom/widget/feed_spec.rb
+++ b/spec/models/custom/widget/feed_spec.rb
@@ -1,13 +1,109 @@
 require "rails_helper"
 
 describe Widget::Feed do
-  describe "#processes" do
-    let(:feed) { build(:widget_feed, kind: "processes", limit: 3) }
+  let(:feed) { build(:widget_feed, kind: "processes", limit: 10) }
 
-    it "returns past processes" do
-      process = create(:legislation_process, :past)
+  describe "#consultation_open_processes" do
+    it "returns open processes tagged with the custom category `ConsultaPrevia`" do
+      create(:legislation_process, :past, tag_list: "ConsultaPrevia")
+      create(:legislation_process, :open)
+      open_process = create(:legislation_process, :open, tag_list: "ConsultaPrevia")
 
-      expect(feed.processes).to eq [process]
+      expect(feed.consultation_open_processes).to eq [open_process]
+    end
+
+    it "returns open processes with the closest end dates first" do
+      create(:legislation_process, :past, tag_list: "ConsultaPrevia")
+      open_process_day = create(:legislation_process, tag_list: "ConsultaPrevia",
+                                                      start_date: 1.day.ago,
+                                                      end_date: 1.day.from_now)
+      open_process_week = create(:legislation_process, tag_list: "ConsultaPrevia",
+                                                       start_date: 1.week.ago,
+                                                       end_date: 1.week.from_now)
+      open_process_month = create(:legislation_process, tag_list: "ConsultaPrevia",
+                                                        start_date: 1.month.ago,
+                                                        end_date: 1.month.from_now)
+
+      processes = [open_process_day, open_process_week, open_process_month]
+      expect(feed.consultation_open_processes).to eq(processes)
+    end
+  end
+
+  describe "#consultation_past_processes" do
+    it "returns past processes tagged with the custom category `ConsultaPrevia`" do
+      past_process = create(:legislation_process, :past, tag_list: "ConsultaPrevia")
+      create(:legislation_process, :past)
+      create(:legislation_process, :open, tag_list: "ConsultaPrevia")
+
+      expect(feed.consultation_past_processes).to eq [past_process]
+    end
+
+    it "returns recently closed processes first" do
+      create(:legislation_process, :open, tag_list: "ConsultaPrevia")
+      past_process_day = create(:legislation_process, tag_list: "ConsultaPrevia",
+                                                      start_date: 1.month.ago,
+                                                      end_date: 1.day.ago)
+      past_process_week = create(:legislation_process, tag_list: "ConsultaPrevia",
+                                                       start_date: 1.month.ago,
+                                                       end_date: 1.week.ago)
+      past_process_month = create(:legislation_process, tag_list: "ConsultaPrevia",
+                                                        start_date: 2.months.ago,
+                                                        end_date: 1.month.ago)
+
+      processes = [past_process_day, past_process_week, past_process_month]
+      expect(feed.consultation_past_processes).to eq(processes)
+    end
+  end
+
+  describe "#participation_open_processes" do
+    it "returns open processes tagged with the custom category `ParticipaciónCiudadana`" do
+      create(:legislation_process, :past, tag_list: "ParticipaciónCiudadana")
+      create(:legislation_process, :open)
+      open_process = create(:legislation_process, :open, tag_list: "ParticipaciónCiudadana")
+
+      expect(feed.participation_open_processes).to eq [open_process]
+    end
+
+    it "returns open processes with the closest end dates first" do
+      create(:legislation_process, :past, tag_list: "ParticipaciónCiudadana")
+      open_process_day = create(:legislation_process, tag_list: "ParticipaciónCiudadana",
+                                                      start_date: 1.day.ago,
+                                                      end_date: 1.day.from_now)
+      open_process_week = create(:legislation_process, tag_list: "ParticipaciónCiudadana",
+                                                       start_date: 1.week.ago,
+                                                       end_date: 1.week.from_now)
+      open_process_month = create(:legislation_process, tag_list: "ParticipaciónCiudadana",
+                                                        start_date: 1.month.ago,
+                                                        end_date: 1.month.from_now)
+
+      processes = [open_process_day, open_process_week, open_process_month]
+      expect(feed.participation_open_processes).to eq(processes)
+    end
+  end
+
+  describe "#participation_past_processes" do
+    it "returns past processes tagged with the custom category `ParticipaciónCiudadana`" do
+      past_process = create(:legislation_process, :past, tag_list: "ParticipaciónCiudadana")
+      create(:legislation_process, :past)
+      create(:legislation_process, :open, tag_list: "ParticipaciónCiudadana")
+
+      expect(feed.participation_past_processes).to eq [past_process]
+    end
+
+    it "returns recently closed processes first" do
+      create(:legislation_process, :open, tag_list: "ParticipaciónCiudadana")
+      past_process_day = create(:legislation_process, tag_list: "ParticipaciónCiudadana",
+                                                      start_date: 1.month.ago,
+                                                      end_date: 1.day.ago)
+      past_process_week = create(:legislation_process, tag_list: "ParticipaciónCiudadana",
+                                                       start_date: 1.month.ago,
+                                                       end_date: 1.week.ago)
+      past_process_month = create(:legislation_process, tag_list: "ParticipaciónCiudadana",
+                                                        start_date: 2.months.ago,
+                                                        end_date: 1.month.ago)
+
+      processes = [past_process_day, past_process_week, past_process_month]
+      expect(feed.participation_past_processes).to eq(processes)
     end
   end
 end

--- a/spec/system/custom/home_spec.rb
+++ b/spec/system/custom/home_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+describe "Home" do
+  before { create(:widget_feed, kind: "processes", limit: 10) }
+
+  context "Processes widget feed" do
+    scenario "Show opened proceses first" do
+      %w[ConsultaPrevia ParticipaciónCiudadana].each do |category|
+        create(:legislation_process, title: "One week process",
+                                     tag_list: category,
+                                     start_date: 1.day.ago,
+                                     end_date: 1.week.from_now)
+        create(:legislation_process, title: "Two weeks process",
+                                     tag_list: category,
+                                     start_date: 1.day.ago,
+                                     end_date: 2.weeks.from_now)
+        create(:legislation_process, title: "One month process",
+                                     tag_list: category,
+                                     start_date: 1.day.ago,
+                                     end_date: 1.month.from_now)
+      end
+
+      visit root_path
+
+      within ".feed-processes", text: "Consulta Previa" do
+        expect(page).to have_css(".open", count: 3)
+        expect("One week process").to appear_before("Two weeks process")
+        expect("Two weeks process").to appear_before("One month process")
+      end
+      within ".feed-processes", text: "Participación Ciudadana" do
+        expect(page).to have_css(".open", count: 3)
+        expect("One week process").to appear_before("Two weeks process")
+        expect("Two weeks process").to appear_before("One month process")
+      end
+    end
+
+    scenario "When opened processes do not reach the widget feed limit it shows past processes" do
+      %w[ConsultaPrevia ParticipaciónCiudadana].each do |category|
+        create(:legislation_process, title: "One week process",
+                                     tag_list: category,
+                                     start_date: 1.day.ago,
+                                     end_date: 1.week.from_now)
+        create(:legislation_process, title: "Two weeks process",
+                                     tag_list: category,
+                                     start_date: 1.day.ago,
+                                     end_date: 2.weeks.from_now)
+
+        create(:legislation_process, title: "Recently closed project",
+                                     tag_list: category,
+                                     start_date: 1.week.ago,
+                                     end_date: 1.day.ago)
+        create(:legislation_process, title: "Older closed project",
+                                     tag_list: category,
+                                     start_date: 2.weeks.ago,
+                                     end_date: 1.week.ago)
+      end
+
+      visit root_path
+
+      within ".feed-processes", text: "Consulta Previa" do
+        expect("One week process").to appear_before("Two weeks process")
+        expect("Two weeks process").to appear_before("Recently closed project")
+        expect("Recently closed project").to appear_before("Older closed project")
+      end
+      within ".feed-processes", text: "Participación Ciudadana" do
+        expect("One week process").to appear_before("Two weeks process")
+        expect("Two weeks process").to appear_before("Recently closed project")
+        expect("Recently closed project").to appear_before("Older closed project")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Objectives

We want to show up to 10 processes,  opened processes first, then ended ones.

The open processes with the closest end dates come first, and then the most recently closed ones.
