### PR TITLE
Error when rendering a link to hidden commentable

### DIFF
--- a/app/views/custom/moderation/comments/index.html.erb
+++ b/app/views/custom/moderation/comments/index.html.erb
@@ -1,0 +1,34 @@
+<%= render Moderation::Shared::IndexComponent.new(@comments) do %>
+  <table class="clear">
+    <thead>
+      <tr>
+        <th><%= t("moderation.comments.index.headers.comment") %></th>
+        <th><%= t("moderation.comments.index.headers.moderate") %></th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @comments.each do |comment| %>
+        <tr id="comment_<%= comment.id %>">
+          <td>
+            <%= comment.commentable_type.constantize.model_name.human %> -
+            <%= link_to comment.commentable.title, commentable_path(comment), target: "_blank" %>
+            <br>
+            <span class="date"><%= l comment.updated_at.to_date %></span>
+            <span class="bullet">&nbsp;&bull;&nbsp;</span>
+            <%= comment.flags_count %><span class="icon-flag flag-disable"></span>
+            <span class="bullet">&nbsp;&bull;&nbsp;</span>
+            <%= comment.author.username %>
+            <br>
+            <div class="moderation-description">
+              <%= comment.body %>
+            </div>
+          </td>
+          <td class="text-center">
+            <%= check_box_tag "comment_ids[]", comment.id, nil, id: "#{dom_id(comment)}_check" %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/custom/moderation/comments/index.html.erb
+++ b/app/views/custom/moderation/comments/index.html.erb
@@ -12,7 +12,11 @@
         <tr id="comment_<%= comment.id %>">
           <td>
             <%= comment.commentable_type.constantize.model_name.human %> -
-            <%= link_to comment.commentable.title, commentable_path(comment), target: "_blank" %>
+            <% if comment.commentable.hidden? %>
+              (<%= t("admin.comments.index.hidden_#{comment.commentable_type.parameterize.underscore}") %>: <%= comment.commentable.title %>)
+            <% else %>
+              <%= link_to comment.commentable.title, commentable_path(comment), target: "_blank" %>
+            <% end %>
             <br>
             <span class="date"><%= l comment.updated_at.to_date %></span>
             <span class="bullet">&nbsp;&bull;&nbsp;</span>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -141,6 +141,7 @@ ignore_unused:
   - "attributes.*"
   - "date.order"
   - "unauthorized.*"
+  - "admin.comments.index.hidden_*"
   - "admin.officials.level_*"
   - "admin.hidden_comments.index.filter*"
   - "admin.banners.index.filters.*"

--- a/config/locales/custom/en/admin.yml
+++ b/config/locales/custom/en/admin.yml
@@ -1,5 +1,8 @@
 en:
   admin:
+    comments:
+      index:
+        hidden_legislation_proposal: Hidden proposal
     documents:
       index:
         legislation:

--- a/config/locales/custom/es/admin.yml
+++ b/config/locales/custom/es/admin.yml
@@ -1,5 +1,8 @@
 es:
   admin:
+    comments:
+      index:
+        hidden_legislation_proposal: Propuesta oculta
     documents:
       index:
         legislation:

--- a/spec/system/custom/moderation/comments_spec.rb
+++ b/spec/system/custom/moderation/comments_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe "Moderate comments" do
+  context "when its commentable is hidden" do
+    scenario "show a text that the commentable is hidden and do not show the link" do
+      moderator = create(:moderator)
+      hidden_proposal = create(:legislation_proposal, :hidden, title: "Proposal with spam comment")
+      create(:comment, commentable: hidden_proposal, body: "SPAM comment", flags_count: 2)
+
+      login_as(moderator.user)
+      visit moderation_comments_path
+
+      expect(page).to have_content "(Hidden proposal: Proposal with spam comment)"
+      expect(page).not_to have_link "Proposal with spam comment"
+    end
+  end
+end


### PR DESCRIPTION
## References
[Moderation comments: Error when rendering a link to hidden commentable](https://github.com/consuldemocracy/consuldemocracy/issues/5253)

## Description
When a comment from a hidden Legislation::Proposal is shown in the moderation comments section the generated link is wrong, it points to an unexisting proposal instead of a legislation proposal.

## Objectives
Render information text for comments when its commentable is hidden