### PR TITLE
Adjust homepage accessibility

### DIFF
--- a/app/assets/stylesheets/custom/layout.scss
+++ b/app/assets/stylesheets/custom/layout.scss
@@ -63,6 +63,22 @@ footer {
       }
     }
   }
+
+  .top-bar-logo {
+    flex-grow: 1;
+    line-height: $line-height;
+    margin-bottom: 0;
+
+    a img {
+      height: rem-calc(48);
+      margin: 0;
+      width: auto;
+
+      @include breakpoint(medium up) {
+        height: auto;
+      }
+    }
+  }
 }
 
 .auth-form .org-name {

--- a/app/assets/stylesheets/custom/widgets/feeds/process.scss
+++ b/app/assets/stylesheets/custom/widgets/feeds/process.scss
@@ -16,14 +16,6 @@
   .feed-item {
     margin-top: $line-height;
 
-    &.open {
-      @include has-fa-icon(unlock-alt, solid);
-
-      &::before {
-        color: $color-success;
-      }
-    }
-
     &.closed {
       @include has-fa-icon(lock, solid);
 

--- a/app/components/custom/layout/footer_component.html.erb
+++ b/app/components/custom/layout/footer_component.html.erb
@@ -1,0 +1,35 @@
+<footer>
+  <div class="row">
+    <div class="small-12 large-4 column">
+      <h1 class="logo">
+        <%= link_to t("layouts.header.open_gov"), root_path %>
+      </h1>
+
+      <p class="info">
+        <%= sanitize(t("layouts.footer.description",
+          open_source: link_to(t("layouts.footer.open_source"), t("layouts.footer.open_source_url"), target: "blank", rel: "nofollow"),
+          consul:  link_to(t("layouts.footer.consul"), t("layouts.footer.consul_url"), target: "blank", rel: "nofollow"))) %>
+      </p>
+    </div>
+
+    <div class="footer-sections small-12 large-8 column">
+      <div class="small-12 medium-4 column">
+        <%= link_to t("layouts.footer.participation_title"), root_path, class: "title" %>
+        <p><%= t("layouts.footer.participation_text") %></p>
+      </div>
+    </div>
+  </div>
+
+  <div class="subfooter row">
+    <div class="small-12 medium-8 column">
+      <%= t("layouts.footer.copyright", year: Time.current.year) %>&nbsp;|
+      <ul class="no-bullet inline-block">
+        <li class="inline-block"><%= link_to t("layouts.footer.privacy"), page_path("privacy") %>&nbsp;|</li>
+        <li class="inline-block"><%= link_to t("layouts.footer.conditions"), page_path("conditions") %>&nbsp;|</li>
+        <li class="inline-block"><%= link_to t("layouts.footer.accessibility"), page_path("accessibility") %></li>
+      </ul>
+    </div>
+
+    <%= render Layout::SocialComponent.new %>
+  </div>
+</footer>

--- a/app/components/custom/layout/footer_component.html.erb
+++ b/app/components/custom/layout/footer_component.html.erb
@@ -1,9 +1,9 @@
 <footer>
   <div class="row">
     <div class="small-12 large-4 column">
-      <h1 class="logo">
+      <h2 class="logo">
         <%= link_to t("layouts.header.open_gov"), root_path %>
-      </h1>
+      </h2>
 
       <p class="info">
         <%= sanitize(t("layouts.footer.description",

--- a/app/components/custom/layout/footer_component.rb
+++ b/app/components/custom/layout/footer_component.rb
@@ -1,0 +1,6 @@
+class Layout::FooterComponent < ApplicationComponent; end
+
+require_dependency Rails.root.join("app", "components", "layout", "footer_component").to_s
+
+class Layout::FooterComponent
+end

--- a/app/views/custom/layouts/_header.html.erb
+++ b/app/views/custom/layouts/_header.html.erb
@@ -1,0 +1,37 @@
+<header>
+  <%= render Layout::RemoteTranslationsButtonComponent.new(@remote_translations) %>
+
+  <div class="top-links">
+    <%= render Layout::LocaleSwitcherComponent.new %>
+    <div class="hide-for-small-only">
+      <%= render Layout::TopLinksComponent.new %>
+    </div>
+  </div>
+
+  <div class="top-bar">
+    <h1>
+      <%= link_to root_path, accesskey: "0" do %>
+        <%= image_tag(image_path_for("logo_header.png"), alt: setting["org_name"]) %>
+      <% end %>
+    </h1>
+
+    <%= render Layout::ResponsiveMenuComponent.new do %>
+      <%= render Layout::AccountMenuComponent.new(current_user) %>
+
+      <div class="show-for-small-only">
+        <div class="subnavigation subnavigation-with-top-links">
+          <%= render Layout::SubnavigationComponent.new %>
+          <%= render Layout::TopLinksComponent.new %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+  <div id="navigation_bar" class="subnavigation">
+    <div class="hide-for-small-only">
+      <%= render Layout::SubnavigationComponent.new %>
+    </div>
+
+    <%= yield :header_addon %>
+  </div>
+</header>

--- a/app/views/custom/layouts/_header.html.erb
+++ b/app/views/custom/layouts/_header.html.erb
@@ -9,11 +9,11 @@
   </div>
 
   <div class="top-bar">
-    <h1>
+    <%= content_tag(controller_name == "welcome" ? "div" : "h1", class: "top-bar-logo") do %>
       <%= link_to root_path, accesskey: "0" do %>
         <%= image_tag(image_path_for("logo_header.png"), alt: setting["org_name"]) %>
       <% end %>
-    </h1>
+    <% end %>
 
     <%= render Layout::ResponsiveMenuComponent.new do %>
       <%= render Layout::AccountMenuComponent.new(current_user) %>

--- a/app/views/custom/welcome/_processes.html.erb
+++ b/app/views/custom/welcome/_processes.html.erb
@@ -4,7 +4,7 @@
       <% Legislation::Process::CATEGORIES.each do |category| %>
         <% kind = feed.kind %>
 
-        <section id="feed_<%= kind %>" class="widget-feed feed-<%= kind %>">
+        <section id="feed_<%= "#{kind}_#{category}".underscore %>" class="widget-feed feed-<%= kind %>">
           <header>
             <h2 class="title"><%= t("welcome.feed.most_active.#{category.underscore}") %></h2>
           </header>

--- a/app/views/custom/welcome/_processes.html.erb
+++ b/app/views/custom/welcome/_processes.html.erb
@@ -12,13 +12,18 @@
           <% collection = category == "ConsultaPrevia" ? "consultation" : "participation" %>
           <% if feed.send("#{collection}_open_processes").any? || feed.send("#{collection}_past_processes").any? %>
             <div class="feed-content">
-              <% ["#{collection}_open_processes", "#{collection}_past_processes"].each do |method| %>
-                <% feed.send(method).each do |item| %>
-                  <div class="feed-item <%= method.include?("open") ? "open" : "closed" %>">
-                    <%= link_to item.title, url_for(item) %>
-                    <span><%= t("welcome.feed.proposals", count: item.proposals.count) %></span>
-                  </div>
-                <% end %>
+              <% feed.send("#{collection}_open_processes").each do |item| %>
+                <div class="feed-item open">
+                  <%= link_to item.title, url_for(item) %>
+                  <span><%= t("welcome.feed.proposals", count: item.proposals.count) %></span>
+                </div>
+              <% end %>
+
+              <% feed.send("#{collection}_past_processes").each do |item| %>
+                <div class="feed-item closed">
+                  <%= link_to t("welcome.feed.past_title", title: item.title), url_for(item) %>
+                  <span><%= t("welcome.feed.proposals", count: item.proposals.count) %></span>
+                </div>
               <% end %>
             </div>
 

--- a/config/locales/custom/es/general.yml
+++ b/config/locales/custom/es/general.yml
@@ -4,6 +4,7 @@ es:
       most_active:
         consulta_previa: Consultas previas
         participación_ciudadana: Procesos de participación ciudadana
+      past_title: "%{title} (Cerrado)"
       proposals:
         one: 1 propuesta
         other: "%{count} propuestas"

--- a/spec/system/custom/home_spec.rb
+++ b/spec/system/custom/home_spec.rb
@@ -20,14 +20,14 @@ describe "Home" do
                                      end_date: 1.month.from_now)
       end
 
-      visit root_path
+      visit root_path(locale: :es)
 
-      within ".feed-processes", text: "Consulta Previa" do
+      within ".feed-processes", text: "Consultas previas" do
         expect(page).to have_css(".open", count: 3)
         expect("One week process").to appear_before("Two weeks process")
         expect("Two weeks process").to appear_before("One month process")
       end
-      within ".feed-processes", text: "Participación Ciudadana" do
+      within ".feed-processes", text: "Procesos de participación ciudadana" do
         expect(page).to have_css(".open", count: 3)
         expect("One week process").to appear_before("Two weeks process")
         expect("Two weeks process").to appear_before("One month process")
@@ -55,14 +55,14 @@ describe "Home" do
                                      end_date: 1.week.ago)
       end
 
-      visit root_path
+      visit root_path(locale: :es)
 
-      within ".feed-processes", text: "Consulta Previa" do
+      within ".feed-processes", text: "Consultas previas" do
         expect("One week process").to appear_before("Two weeks process")
         expect("Two weeks process").to appear_before("Recently closed project")
         expect("Recently closed project").to appear_before("Older closed project")
       end
-      within ".feed-processes", text: "Participación Ciudadana" do
+      within ".feed-processes", text: "Procesos de participación ciudadana" do
         expect("One week process").to appear_before("Two weeks process")
         expect("Two weeks process").to appear_before("Recently closed project")
         expect("Recently closed project").to appear_before("Older closed project")

--- a/spec/system/custom/site_customization/custom_pages_spec.rb
+++ b/spec/system/custom/site_customization/custom_pages_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe "Custom Pages" do
+  context "New custom page" do
+    context "Published" do
+      scenario "Don't show subtitle if its blank" do
+        custom_page = create(:site_customization_page, :published,
+          slug: "slug-without-subtitle",
+          title_en: "Custom page",
+          subtitle_en: "",
+          content_en: "Text for new custom page",
+          print_content_flag: false
+        )
+
+        visit custom_page.url
+
+        expect(page).to have_title("Custom page")
+        expect(page).to have_selector("h1", text: "Custom page")
+        expect(page).to have_content("Text for new custom page")
+        expect(page).not_to have_selector("h2")
+        expect(page).not_to have_content("Print this info")
+      end
+    end
+  end
+end

--- a/spec/system/custom/site_customization/custom_pages_spec.rb
+++ b/spec/system/custom/site_customization/custom_pages_spec.rb
@@ -15,10 +15,13 @@ describe "Custom Pages" do
         visit custom_page.url
 
         expect(page).to have_title("Custom page")
-        expect(page).to have_selector("h1", text: "Custom page")
-        expect(page).to have_content("Text for new custom page")
-        expect(page).not_to have_selector("h2")
-        expect(page).not_to have_content("Print this info")
+
+        within ".wrapper" do
+          expect(page).to have_selector("h1", text: "Custom page")
+          expect(page).to have_content("Text for new custom page")
+          expect(page).not_to have_selector("h2")
+          expect(page).not_to have_content("Print this info")
+        end
       end
     end
   end

--- a/spec/system/site_customization/custom_pages_spec.rb
+++ b/spec/system/site_customization/custom_pages_spec.rb
@@ -38,7 +38,7 @@ describe "Custom Pages" do
         expect(page).to have_content("Print this info")
       end
 
-      scenario "Don't show subtitle if its blank" do
+      scenario "Don't show subtitle if its blank", :consul do
         custom_page = create(:site_customization_page, :published,
           slug: "slug-without-subtitle",
           title_en: "Custom page",


### PR DESCRIPTION
## Objectives

* Make it easier to distinguish between open and closed processes on the homepage
* Don't show duplicate `<h1>` tags on the homepage

## Visual Changes

### Before these changes

![Open processes are marked with an open lock and past processes are marked with a closed lock](https://github.com/juntadecastillayleon/participacyl/assets/35156/4dae3be1-068b-4f48-a841-65995bba3187)


### After these changes

![Open processes are nor marked with a lock and past processes are marked with a closed lock](https://github.com/juntadecastillayleon/participacyl/assets/35156/3b37e814-eaf4-4f03-9c01-bc04ef6d9210)
