### PR TITLE
Refresh CSRF Token when using Turbolinks

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -111,6 +111,7 @@
 //= require budget_edit_associations
 //= require budget_hide_money
 //= require datepicker
+//= require authenticity_token_refresh
 //= require_tree ./admin
 //= require_tree ./sdg
 //= require_tree ./sdg_management
@@ -174,6 +175,7 @@ var initialize_modules = function() {
   App.Datepicker.initialize();
   App.SDGRelatedListSelector.initialize();
   App.SDGManagementRelationSearch.initialize();
+  App.AuthenticityTokenRefresh.initialize();
 };
 
 var destroy_non_idempotent_modules = function() {

--- a/app/assets/javascripts/authenticity_token_refresh.js
+++ b/app/assets/javascripts/authenticity_token_refresh.js
@@ -1,0 +1,8 @@
+(function() {
+  "use strict";
+  App.AuthenticityTokenRefresh = {
+    initialize: function() {
+      $.rails.refreshCSRFTokens();
+    }
+  };
+}).call(this);


### PR DESCRIPTION
## References

* consuldemocracy/consuldemocracy/issues/5160

We've been recording multiple 422 error because `ActionController::InvalidAuthenticityToken`. We notice we also have the same issue described in the referenced issue above. 

## Objectives

Avoid `ActionController::InvalidAuthenticityToken` exception because of Turbolinks.

This change fixes the behaviour of the original issue.

## Visual Changes

The user is now redirected to the sign-in page instead of showing a 422 error. 

